### PR TITLE
Fixes bug tablet: text in datagrid searchfield(Date) not centered vertically.

### DIFF
--- a/styles/sass/lib/components/_grid.scss
+++ b/styles/sass/lib/components/_grid.scss
@@ -43,6 +43,8 @@
                 .form-control {
                     height: 28px;
                     font-size: 11px;
+                    line-height: 1em;
+                    vertical-align: middle;
                 }
                 select.form-control {
                     padding: 3px;


### PR DESCRIPTION
![screenshot 1](https://user-images.githubusercontent.com/39378616/41232530-f6c8f83c-6d86-11e8-83ad-4ade77d14782.jpg)
